### PR TITLE
processors component not used

### DIFF
--- a/examples/audio_classifier/python/audio_classification.ipynb
+++ b/examples/audio_classifier/python/audio_classification.ipynb
@@ -160,7 +160,6 @@
         "import numpy as np\n",
         "\n",
         "from mediapipe.tasks import python\n",
-        "from mediapipe.tasks.python.components import processors\n",
         "from mediapipe.tasks.python.components import containers\n",
         "from mediapipe.tasks.python import audio\n",
         "from scipy.io import wavfile\n",


### PR DESCRIPTION
```py
from mediapipe.tasks.python.components import processors
```
Is not used in the code