### PR TITLE
Integrate Stale bot with PR template and fixed typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Description
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+
+Fixes # (issue)
+
+### Checklist
+Please ensure the following items are complete before submitting a pull request:
+
+- [ ] My code follows the code style of the project.
+- [ ] I have updated the documentation (if applicable).
+- [ ] I have added tests to cover my changes.
+
+### Type of Change
+Please check the relevant option below:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Documentation update (non-breaking change which updates documentation)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+### Screenshots
+If applicable, please add screenshots to help explain your changes.
+
+### Additional Notes
+Add any additional information or context about the pull request here.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,36 @@
+# Copyright 2022 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+#
+# This file was assembled from multiple pieces, whose use is documented
+# throughout. Please refer to the TensorFlow dockerfiles documentation
+# for more information.
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 60
+# Number of days of inactivity before a reminder comment is posted. Set to `false` to disable
+daysBeforeReminder: 4
+# Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled)
+onlyLabels:
+ - stat:awaiting response
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+closeComment: >
+  Closing as stale. Please reopen if you'd like to work on this further.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This repo hosts the official MediaPipe samples with a goal of showing the fundamentals steps involved to create apps with our machine learning platform. 
+This repo hosts the official MediaPipe samples with a goal of showing the fundamental steps involved to create apps with our machine learning platform. 
 
-External PRs for fixes are welcome, however new sample/demo PRs will likely be rejected to maintain the simplicity of this repo for ongoing maintenence. It is strongly recommended that contributors who are interested in submitting more complex samples or demos host their samples in their own public repos and create written tutorials to share with the community. Contributors can also submit these projects and tutorials to the [Google DevLibrary](https://devlibrary.withgoogle.com/)
+External PRs for fixes are welcome, however new sample/demo PRs will likely be rejected to maintain the simplicity of this repo for ongoing maintenance. It is strongly recommended that contributors who are interested in submitting more complex samples or demos host their samples in their own public repos and create written tutorials to share with the community. Contributors can also submit these projects and tutorials to the [Google DevLibrary](https://devlibrary.withgoogle.com/)
 
 
 MediaPipe Solutions streamlines on-device ML development and deployment with flexible low-code / no-code tools that provide the modular building blocks for creating custom high-performance solutions for cross-platform deployment. It consists of the following components:


### PR DESCRIPTION
#### Description

The objective is to add a Stale bot and a PR template to streamline the contribution process. Additionally, fixed a few typos and grammatical mistakes in [README](https://github.com/googlesamples/mediapipe/blob/main/README.md).

Partially Resolves: [#94](https://github.com/googlesamples/mediapipe/issues/94#:~:text=P.S.%3A%20Please%20consider%20adding%20an%20Issue%20Template%20as%20well%20as%20Stale%20bot%20for%20this%20repository%20or%20better%20import%20the%20same%20one%20from%20here%20%26%20set%20the%20config%20value%20accordingly.%20If%20assigned%2C%20I%27d%20love%20to%20raise%20a%20PR%20for%20the%20same!)
cc: @PaulTR 
