### PR TITLE
Add exception handler to CameraFragment.kt

### DIFF
--- a/examples/object_detection/android/app/src/main/java/com/google/mediapipe/examples/objectdetection/fragments/CameraFragment.kt
+++ b/examples/object_detection/android/app/src/main/java/com/google/mediapipe/examples/objectdetection/fragments/CameraFragment.kt
@@ -204,8 +204,12 @@ class CameraFragment : Fragment(), ObjectDetectorHelper.DetectorListener {
                     p2: Int,
                     p3: Long
                 ) {
-                    objectDetectorHelper.currentDelegate = p2
-                    updateControlsUi()
+                    try {
+                        objectDetectorHelper.currentDelegate = p2
+                        updateControlsUi()
+                    } catch(e: UninitializedPropertyAccessException) {
+                        Log.e(TAG, "ObjectDetectorHelper has not been initialized yet.")
+                    }
                 }
 
                 override fun onNothingSelected(p0: AdapterView<*>?) {
@@ -226,8 +230,12 @@ class CameraFragment : Fragment(), ObjectDetectorHelper.DetectorListener {
                     p2: Int,
                     p3: Long
                 ) {
-                    objectDetectorHelper.currentModel = p2
-                    updateControlsUi()
+                    try {
+                        objectDetectorHelper.currentDelegate = p2
+                        updateControlsUi()
+                    } catch(e: UninitializedPropertyAccessException) {
+                        Log.e(TAG, "ObjectDetectorHelper has not been initialized yet.")
+                    }
                 }
 
                 override fun onNothingSelected(p0: AdapterView<*>?) {


### PR DESCRIPTION
### Description
Add exception catch to an adapter that runs before the helper is initialised in Object Detection Android App

Fixes # (issue)
```
FATAL EXCEPTION: main
Process: com.google.mediapipe.examples.objectdetection, PID: 20275
java.lang.RuntimeException: lateinit property objectDetectorHelper has not been initialized at com.google.mediapipe.examples.objectdetection.fragments.CameraFragment.initBottomSheetControls(CameraFragment.kt:236)
at android.widget.AdapterView.fireOnSelected(AdapterView.java:979)
at android.widget.AdapterView.dispatchOnItemSelected(AdapterView.java:968)
at android.widget.AdapterView.-$$Nest$mdispatchOnItemSelected(Unknown Source:0)
at android.widget.AdapterView$SelectionNotifier.run(AdapterView.java:932)
at android.os.Handler.handleCallback(Handler.java:942)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:240)
at android.os.Looper.loop(Looper.java:351)
at android.app.ActivityThread.main(ActivityThread.java:8399)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)
```
### Checklist
Please ensure the following items are complete before submitting a pull request:

- [x] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.

### Additional Notes
This is a known error which was earlier fixed for [Gesture Recognition](https://github.com/googlesamples/mediapipe/commit/7d3d22e1e0a41e86c70085dbbd9aac766d016470)
