### PR TITLE
Safari Background Segmentation Example Changes

### DIFF
--- a/tutorials/background_segmenter/code/camera.js
+++ b/tutorials/background_segmenter/code/camera.js
@@ -45,9 +45,7 @@ export default class Camera {
             };
             this.stream = await navigator.mediaDevices.getUserMedia(constraints);
             this.videoElement.srcObject = this.stream;
-            if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
-                this.videoElement.play();
-            }
+            await this.videoElement.play();
             return new Promise((resolve) => {
                 this.videoElement.onloadedmetadata = () => {
                     this.isRunning = true;

--- a/tutorials/background_segmenter/code/camera.js
+++ b/tutorials/background_segmenter/code/camera.js
@@ -45,6 +45,8 @@ export default class Camera {
             };
             this.stream = await navigator.mediaDevices.getUserMedia(constraints);
             this.videoElement.srcObject = this.stream;
+            // Safari requires explicitly calling play() to start stream
+            if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) this.videoElement.play();
             return new Promise((resolve) => {
                 this.videoElement.onloadedmetadata = () => {
                     this.isRunning = true;

--- a/tutorials/background_segmenter/code/camera.js
+++ b/tutorials/background_segmenter/code/camera.js
@@ -45,8 +45,9 @@ export default class Camera {
             };
             this.stream = await navigator.mediaDevices.getUserMedia(constraints);
             this.videoElement.srcObject = this.stream;
-            // Safari requires explicitly calling play() to start stream
-            if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) this.videoElement.play();
+            if(/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+                this.videoElement.play();
+            }
             return new Promise((resolve) => {
                 this.videoElement.onloadedmetadata = () => {
                     this.isRunning = true;

--- a/tutorials/background_segmenter/code/index.html
+++ b/tutorials/background_segmenter/code/index.html
@@ -21,7 +21,7 @@
         <h3>Segmenting the background using the MediaPipe Image Segmentation Task</h3>
     </div>
     <div class="col s1 center">
-        <video id="video" style="display: none; transform: scaleX(-1)" autoplay></video>
+        <video id="video" style="display: none; transform: scaleX(-1)" autoplay webkit-playsinline playsinline></video>
         <canvas id="canvas" width="480" height="360" style="border: gray solid 2px"></canvas>
     </div>
     <div class="col s1 center">


### PR DESCRIPTION
### Description
For the JS Background Segmentation tutorial, Safari requires a couple minor changes to the code to function properly. If on mobile, ```webkit-playsinline``` and ```playsinline``` should be used to prevent the video overlay. Also, Safari requires explicitly calling ```play()``` on the video element. These changes were made to save someone a little bit of time if they use the tutorial on Safari.

The checklist mentions adding tests but I don't see any.

Fixes # (issue)

JS Background Segmentation tutorial didn't work on Safari.

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [X] My code follows the code style of the project.
- [X] I have updated the documentation (if applicable).
- [X] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
N/A

### Additional Notes
I know this is Google ;) Safari smh
