### PR TITLE
Add convert.py for Image Generator

### DIFF
--- a/tools/image_generator_converter/README.md
+++ b/tools/image_generator_converter/README.md
@@ -1,0 +1,10 @@
+# Setup
+Use pip to install the following dependencies
+```
+pip install torch typing_extensions numpy Pillow requests pytorch_lightning
+```
+
+
+# Usage
+Convert the model checkpoints into a bins folder using the script:
+`python3 convert.py --ckpt_path <ckpt_path> --output_path <output_path>`

--- a/tools/image_generator_converter/README.md
+++ b/tools/image_generator_converter/README.md
@@ -1,10 +1,12 @@
 # Setup
 Use pip to install the following dependencies
 ```
-pip install torch typing_extensions numpy Pillow requests pytorch_lightning
+pip install torch typing_extensions numpy Pillow requests pytorch_lightning absl-py
 ```
 
 
 # Usage
 Convert the model checkpoints into a bins folder using the script:
-`python3 convert.py --ckpt_path <ckpt_path> --output_path <output_path>`
+```
+python3 convert.py --ckpt_path <ckpt_path> --output_path <output_path>
+```

--- a/tools/image_generator_converter/convert.py
+++ b/tools/image_generator_converter/convert.py
@@ -1,0 +1,51 @@
+"""Helper script to convert diffusion checkpoints to format used by image generator."""
+
+import os
+
+from absl import app
+from absl import flags
+import requests
+import torch as th
+
+
+_CKPT_PATH = flags.DEFINE_string(
+    "ckpt_path", default=None, help="Path to checkpoint file", required=True)
+_OUTPUT_PATH = flags.DEFINE_string(
+    "output_path", default="bins", help="Output folder path", required=False)
+
+VOCAB_URL = "https://openaipublic.blob.core.window.net/clip/bpe_simple_vocab_16e6.txt"
+
+
+def run(ckpt_path, output_path):
+  """Converts the checkpoint and saves the result.
+
+  Args:
+    ckpt_path: Source checkpoint path
+    output_path: Result folder directory
+  """
+  os.makedirs(output_path, exist_ok=True)
+  ckpt = th.load(ckpt_path, map_location="cpu")
+
+  vocab_dest = os.path.join(output_path, os.path.basename(VOCAB_URL))
+  if not os.path.exists(vocab_dest):
+    with requests.get(VOCAB_URL, stream=True) as response:
+      with open(vocab_dest, "wb") as vocab_file:
+        for c in response.iter_content(chunk_size=8192):
+          vocab_file.write(c)
+
+  for k, v in ckpt["state_dict"].items():
+    if "first_stage_model.encoder" in k:
+      continue
+    if not hasattr(v, "numpy"):
+      continue
+    output_bin_file = os.path.join(output_path, f"{k}.bin")
+    v.numpy().astype("float16").tofile(output_bin_file)
+
+
+def main(_) -> None:
+  ckpt_path = _CKPT_PATH.value
+  output_path = _OUTPUT_PATH.value
+  run(ckpt_path, output_path)
+
+if __name__ == "__main__":
+  app.run(main)

--- a/tools/image_generator_converter/convert.py
+++ b/tools/image_generator_converter/convert.py
@@ -13,7 +13,7 @@ _CKPT_PATH = flags.DEFINE_string(
 _OUTPUT_PATH = flags.DEFINE_string(
     "output_path", default="bins", help="Output folder path", required=False)
 
-VOCAB_URL = "https://openaipublic.blob.core.window.net/clip/bpe_simple_vocab_16e6.txt"
+VOCAB_URL = "https://openaipublic.blob.core.windows.net/clip/bpe_simple_vocab_16e6.txt"
 
 
 def run(ckpt_path, output_path):


### PR DESCRIPTION
### Description
This PR adds a convert.py script which is used to convert stable diffusion pytorch checkpoints into a folder of bin files which can be used with MediaPipe Image Generator.

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [x] My code follows the code style of the project.
- [x] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Additional Notes
Tested locally to verify this works as expected.
