### PR TITLE
Fixed a preview issue with OverlayView.

### DIFF
--- a/examples/image_segmentation/android/confidence_mask/app/src/main/java/com/google/mediapipe/examples/imagesegmenter/OverlayView.kt
+++ b/examples/image_segmentation/android/confidence_mask/app/src/main/java/com/google/mediapipe/examples/imagesegmenter/OverlayView.kt
@@ -64,7 +64,7 @@ class OverlayView(context: Context?, attrs: AttributeSet?) :
             val confidence = byteBuffer.get()
 
             val color =
-                Color.argb(255 * confidence, 0.0f, 0.0f, 128.0f)
+                Color.argb((255 * confidence).toInt(), 0, 0, 128)
             pixels[i] = color
         }
         val image = Bitmap.createBitmap(


### PR DESCRIPTION
Fixed a preview issue with OverlayView.

Color.argb parameter to accept float values within the range of 0-1, while introducing int parameter for values in the range of 0-255.

