### PR TITLE
Fix typo in Android Poselandmark CameraFragment.kt

### DIFF
--- a/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/fragment/CameraFragment.kt
+++ b/examples/pose_landmarker/android/app/src/main/java/com/google/mediapipe/examples/poselandmarker/fragment/CameraFragment.kt
@@ -136,7 +136,7 @@ class CameraFragment : Fragment(), PoseLandmarkerHelper.LandmarkerListener {
             setUpCamera()
         }
 
-        // Create the PoseLandmarkerHelper that will posele the inference
+        // Create the PoseLandmarkerHelper that will handle the inference
         backgroundExecutor.execute {
             poseLandmarkerHelper = PoseLandmarkerHelper(
                 context = requireContext(),


### PR DESCRIPTION
### Description
In the CameraFragment.kt file of the Android Poselandmark module, I've corrected a typo. The word posele has been changed to handle.

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [x] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.

### Additional Notes
Add any additional information or context about the pull request here.
