### PR TITLE
Fix logic error in detectVideoFile when handLandmarker result is null (Android)

### DIFF
--- a/examples/hand_landmarker/android/app/src/main/java/com/google/mediapipe/examples/handlandmarker/HandLandmarkerHelper.kt
+++ b/examples/hand_landmarker/android/app/src/main/java/com/google/mediapipe/examples/handlandmarker/HandLandmarkerHelper.kt
@@ -261,13 +261,13 @@ class HandLandmarkerHelper(
                     handLandmarker?.detectForVideo(mpImage, timestampMs)
                         ?.let { detectionResult ->
                             resultList.add(detectionResult)
-                        } ?: {
-                        didErrorOccurred = true
-                        handLandmarkerHelperListener?.onError(
-                            "ResultBundle could not be returned" +
-                                    " in detectVideoFile"
-                        )
-                    }
+                        } ?: run{
+                            didErrorOccurred = true
+                            handLandmarkerHelperListener?.onError(
+                                "ResultBundle could not be returned" +
+                                        " in detectVideoFile"
+                            )
+                        }
                 }
                 ?: run {
                     didErrorOccurred = true


### PR DESCRIPTION
### Description
handLandmarker?.detectForVideo(mpImage, timestampMs) null result handling

Fixes #294 

- ?: => ?: run
- Aligned code indentation.