### PR TITLE
Add explicit PyTorch install for LLM Converter

### DIFF
--- a/examples/llm_inference/conversion/llm_conversion.ipynb
+++ b/examples/llm_inference/conversion/llm_conversion.ipynb
@@ -740,6 +740,7 @@
         "display(install_out)\n",
         "with install_out:\n",
         "  !pip install mediapipe\n",
+        "  !pip install torch\n",
         "  !pip install huggingface_hub\n",
         "  import os\n",
         "  from huggingface_hub import hf_hub_download\n",


### PR DESCRIPTION
We are removing this from the explicit dependencies due to slow install time.
