### PR TITLE
Only pass the last model reply as part of the prompt.

### DIFF
--- a/examples/llm_inference/ios/.gitignore
+++ b/examples/llm_inference/ios/.gitignore
@@ -1,3 +1,4 @@
 *.bin
 InferenceExample.xcodeproj/xcuserdata/
+InferenceExample.xcodeproj/xcshareddata/
 .DS_Store

--- a/examples/llm_inference/ios/InferenceExample.xcodeproj/project.pbxproj
+++ b/examples/llm_inference/ios/InferenceExample.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"InferenceExample/Preview Content\"";
-				DEVELOPMENT_TEAM = M3D535GFVK;
+				DEVELOPMENT_TEAM = 98N43B5Q6H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -351,10 +351,10 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mediapipe.InferenceExample.foo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mediapipe.InferenceExample.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -371,7 +371,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"InferenceExample/Preview Content\"";
-				DEVELOPMENT_TEAM = M3D535GFVK;
+				DEVELOPMENT_TEAM = 98N43B5Q6H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -389,10 +389,10 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mediapipe.InferenceExample.foo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mediapipe.InferenceExample.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/examples/llm_inference/ios/InferenceExample/OnDeviceModel.swift
+++ b/examples/llm_inference/ios/InferenceExample/OnDeviceModel.swift
@@ -42,6 +42,7 @@ final class OnDeviceModel {
       do {
         try inference.generateResponseAsync(inputText: prompt) { partialResponse, error in
           if let error = error {
+            print("Error 1: \(error)")
             continuation.resume(throwing: error)
             return
           }
@@ -55,6 +56,7 @@ final class OnDeviceModel {
           partialResult = ""
         }
       } catch let error {
+        print("Error 2: \(error)")
         continuation.resume(throwing: error)
       }
     }
@@ -84,19 +86,19 @@ final class Chat {
     return "<start_of_turn>model\n\(newMessage)<end_of_turn>\n"
   }
 
-  private func compositePrompt(newMessage: String) -> String {
-    return history.joined(separator: "\n") + "\n" + newMessage
+  private func compositePrompt() -> String {
+      return history.suffix(2).joined(separator: "\n")
   }
 
-
   func sendMessage(_ text: String, progress: @escaping (String) -> Void) async throws -> String {
-    let prompt = compositePrompt(newMessage: composeUserTurn(text))
-    let reply = try await model.generateResponse(prompt: prompt, progress: progress)
-
-    history = [prompt, composeModelTurn(reply)]
-
+    history.append(composeUserTurn(text))
+    let prompt = compositePrompt()
     print("Prompt: \(prompt)")
+
+    let reply = try await model.generateResponse(prompt: prompt, progress: progress)
     print("Reply: \(reply)")
+    history.append(composeModelTurn(reply))
+
     return reply
   }
 


### PR DESCRIPTION
Incorporates some fixes and improvements.
 - Maintain entire user history, but only use the last model response in prompt.
 - Move prompt logging before model invocation.
 - Add some error logs.
 - Modify xcodeproj config to only run on ios, not mac to avoid build failures.

### Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist
Please ensure the following items are complete before submitting a pull request:

- [ ] My code follows the code style of the project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.

### Type of Change
Please check the relevant option below:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update (non-breaking change which updates documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
If applicable, please add screenshots to help explain your changes.

### Additional Notes
Add any additional information or context about the pull request here.
